### PR TITLE
De-encapsulate `Input`, `RerandomizedOutput`, and `OutputBlinds`

### DIFF
--- a/crypto/fcmps/src/prover/blinds.rs
+++ b/crypto/fcmps/src/prover/blinds.rs
@@ -138,10 +138,14 @@ pub struct OutputBlinds<G: DivisorCurve>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
-  pub(crate) o_blind: OBlind<G>,
-  pub(crate) i_blind: IBlind<G>,
-  pub(crate) i_blind_blind: IBlindBlind<G>,
-  pub(crate) c_blind: CBlind<G>,
+  /// Blind for O~.
+  pub o_blind: OBlind<G>,
+  /// Blind for I~.
+  pub i_blind: IBlind<G>,
+  /// Blind for R.
+  pub i_blind_blind: IBlindBlind<G>,
+  /// Blind for C~.
+  pub c_blind: CBlind<G>,
 }
 
 impl<G: DivisorCurve> OutputBlinds<G>

--- a/networks/monero/ringct/fcmp++/src/lib.rs
+++ b/networks/monero/ringct/fcmp++/src/lib.rs
@@ -170,10 +170,14 @@ pub fn FCMP_PARAMS() -> &'static FcmpParams<Curves> {
 /// be preferred.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Zeroize)]
 pub struct Input {
-  O_tilde: <Ed25519 as Ciphersuite>::G,
-  I_tilde: <Ed25519 as Ciphersuite>::G,
-  R: <Ed25519 as Ciphersuite>::G,
-  C_tilde: <Ed25519 as Ciphersuite>::G,
+  /// O~.
+  pub O_tilde: <Ed25519 as Ciphersuite>::G,
+  /// I~.
+  pub I_tilde: <Ed25519 as Ciphersuite>::G,
+  /// R.
+  pub R: <Ed25519 as Ciphersuite>::G,
+  /// C~.
+  pub C_tilde: <Ed25519 as Ciphersuite>::G,
 }
 
 impl Input {
@@ -215,26 +219,6 @@ impl Input {
     transcript.update(self.C_tilde.to_bytes());
     transcript.update(self.R.to_bytes());
     transcript.update(L.to_bytes());
-  }
-
-  /// O~ from the input commitment.
-  pub fn O_tilde(&self) -> <Ed25519 as Ciphersuite>::G {
-    self.O_tilde
-  }
-
-  /// I~ from the input commitment.
-  pub fn I_tilde(&self) -> <Ed25519 as Ciphersuite>::G {
-    self.I_tilde
-  }
-
-  /// R from the input commitment.
-  pub fn R(&self) -> <Ed25519 as Ciphersuite>::G {
-    self.R
-  }
-
-  /// C~ from the input commitment (the pseudo-out).
-  pub fn C_tilde(&self) -> <Ed25519 as Ciphersuite>::G {
-    self.C_tilde
   }
 }
 

--- a/networks/monero/ringct/fcmp++/src/sal/mod.rs
+++ b/networks/monero/ringct/fcmp++/src/sal/mod.rs
@@ -30,11 +30,16 @@ pub mod multisig;
 /// A re-randomized output.
 #[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct RerandomizedOutput {
-  input: Input,
-  r_o: <Ed25519 as Ciphersuite>::F,
-  r_i: <Ed25519 as Ciphersuite>::F,
-  r_r_i: <Ed25519 as Ciphersuite>::F,
-  r_c: <Ed25519 as Ciphersuite>::F,
+  /// FCMP input tuple (O~, I~, R, C~).
+  pub input: Input,
+  /// r_o such that O~ = O + r_o T.
+  pub r_o: <Ed25519 as Ciphersuite>::F,
+  /// r_i such that I~ = I + r_i U
+  pub r_i: <Ed25519 as Ciphersuite>::F,
+  /// r_r_i such that R = r_i V + r_r_i T
+  pub r_r_i: <Ed25519 as Ciphersuite>::F,
+  /// r_c such that C~ = C + r_c G.
+  pub r_c: <Ed25519 as Ciphersuite>::F,
 }
 
 impl core::fmt::Debug for RerandomizedOutput {
@@ -103,11 +108,6 @@ impl RerandomizedOutput {
   /// The scalar to use with `CBlind::new`.
   pub fn c_blind(&self) -> <Ed25519 as Ciphersuite>::F {
     -self.r_c
-  }
-
-  /// The input tuple produced by this output and set of rerandomizations.
-  pub fn input(&self) -> Input {
-    self.input
   }
 }
 


### PR DESCRIPTION
IMO these classes more or less act like "parameter shuttles" for proving/verifying, and as such doesn't make sense to encapsulate these fields. There's downstream code right now that would benefit from the usability of not having these fields be private. 

Related to (replaces?) #21

