### PR TITLE
Serializable blinds + use u8 for bit decomposition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,7 @@ dependencies = [
  "ff",
  "group",
  "hex",
+ "monero-io",
  "pasta_curves 0.5.1 (git+https://github.com/kayabaNerve/pasta_curves.git)",
  "rand_core",
  "std-shims",

--- a/crypto/divisors/Cargo.toml
+++ b/crypto/divisors/Cargo.toml
@@ -26,6 +26,8 @@ hex = { version = "0.4", default-features = false, optional = true }
 dalek-ff-group = { path = "../dalek-ff-group", default-features = false, optional = true }
 pasta_curves = { version = "0.5", git = "https://github.com/kayabaNerve/pasta_curves.git", default-features = false, features = ["bits", "alloc"], optional = true }
 
+monero-io = { path = "../../networks/monero/io", default-features = false }
+
 [dev-dependencies]
 rand_core = { version = "0.6", features = ["getrandom"] }
 

--- a/crypto/divisors/src/lib.rs
+++ b/crypto/divisors/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(missing_docs)]
 #![allow(non_snake_case)]
 
-use std_shims::{vec, vec::Vec};
+use std_shims::{vec, vec::Vec, io};
 
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConditionallySelectable};
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -16,6 +16,7 @@ use group::{
 
 mod poly;
 pub use poly::Poly;
+use poly::read_scalar;
 
 #[cfg(test)]
 mod tests;
@@ -272,7 +273,7 @@ pub fn new_divisor<C: DivisorCurve>(points: &[C]) -> Option<Poly<C::FieldElement
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct ScalarDecomposition<F: Zeroize + PrimeFieldBits> {
   scalar: F,
-  decomposition: Vec<u64>,
+  decomposition: Vec<u8>,
 }
 
 impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
@@ -298,9 +299,9 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
 
     // Obtain the bits of the scalar
     let num_bits_usize = usize::try_from(num_bits).unwrap();
-    let mut decomposition = vec![0; num_bits_usize];
+    let mut decomposition = vec![0u8; num_bits_usize];
     for (i, bit) in scalar.to_le_bits().into_iter().take(num_bits_usize).enumerate() {
-      let bit = u64::from(u8::from(bit));
+      let bit = u8::from(bit);
       decomposition[i] = bit;
     }
 
@@ -314,7 +315,7 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
       let mut decomposition_of_modulus = vec![0; num_bits_usize];
       // Decompose negative one
       for (i, bit) in (-F::ONE).to_le_bits().into_iter().take(num_bits_usize).enumerate() {
-        let bit = u64::from(u8::from(bit));
+        let bit = u8::from(bit);
         decomposition_of_modulus[i] = bit;
       }
       // Increment it by one
@@ -334,7 +335,7 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
     // Calculcate the sum of the coefficients
     let mut sum_of_coefficients: u64 = 0;
     for decomposition in &decomposition {
-      sum_of_coefficients += *decomposition;
+      sum_of_coefficients += u64::from(*decomposition);
     }
 
     /*
@@ -411,7 +412,7 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
         done |= should_act;
       }
     }
-    debug_assert!(bool::from(decomposition.iter().sum::<u64>().ct_eq(&num_bits)));
+    debug_assert!(bool::from(decomposition.iter().map(|&x| x as u64).sum::<u64>().ct_eq(&num_bits)));
 
     Some(ScalarDecomposition { scalar, decomposition })
   }
@@ -422,7 +423,7 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
   }
 
   /// The decomposition of the scalar.
-  pub fn decomposition(&self) -> &[u64] {
+  pub fn decomposition(&self) -> &[u8] {
     &self.decomposition
   }
 
@@ -456,7 +457,7 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
       }
 
       // Increase the next write start by the coefficient.
-      write_above += coefficient;
+      write_above += u64::from(*coefficient);
       generator = generator.double();
     }
 
@@ -464,6 +465,26 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
     let res = new_divisor(&divisor_points).unwrap();
     divisor_points.zeroize();
     res
+  }
+
+  /// Write the ScalarDecomposition
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    w.write_all(self.scalar.to_repr().as_ref())?;
+    w.write_all(&self.decomposition)
+  }
+
+  /// Read a ScalarDecomposition
+  pub fn read(reader: &mut impl io::Read) -> io::Result<Self> {
+    let scalar = read_scalar(reader)?;
+
+    let num_bits_usize = usize::try_from(F::NUM_BITS).unwrap();
+    let mut decomposition = vec![0u8; num_bits_usize];
+    reader.read_exact(decomposition.as_mut())?;
+
+    Ok(Self {
+      scalar,
+      decomposition
+    })
   }
 }
 

--- a/crypto/divisors/src/lib.rs
+++ b/crypto/divisors/src/lib.rs
@@ -412,7 +412,9 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
         done |= should_act;
       }
     }
-    debug_assert!(bool::from(decomposition.iter().map(|&x| x as u64).sum::<u64>().ct_eq(&num_bits)));
+    debug_assert!(bool::from(
+      decomposition.iter().map(|&x| x as u64).sum::<u64>().ct_eq(&num_bits)
+    ));
 
     Some(ScalarDecomposition { scalar, decomposition })
   }
@@ -481,10 +483,7 @@ impl<F: Zeroize + PrimeFieldBits> ScalarDecomposition<F> {
     let mut decomposition = vec![0u8; num_bits_usize];
     reader.read_exact(decomposition.as_mut())?;
 
-    Ok(Self {
-      scalar,
-      decomposition
-    })
+    Ok(Self { scalar, decomposition })
   }
 }
 

--- a/crypto/divisors/src/poly.rs
+++ b/crypto/divisors/src/poly.rs
@@ -1,10 +1,23 @@
 use core::ops::{Add, Neg, Sub, Mul, Rem};
-use std_shims::{vec, vec::Vec};
+use std_shims::{vec, vec::Vec, io};
 
 use subtle::{Choice, ConstantTimeEq, ConstantTimeGreater, ConditionallySelectable};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
+use monero_io::{write_vec, read_vec};
+
 use group::ff::PrimeField;
+
+// Helper function to read a scalar
+pub(crate) fn read_scalar<F: PrimeField>(r: &mut impl io::Read) -> io::Result<F> {
+  let mut repr = F::Repr::default();
+  r.read_exact(repr.as_mut())?;
+  let scalar = F::from_repr(repr);
+  if scalar.is_none().into() {
+    Err(io::Error::new(io::ErrorKind::Other, "invalid scalar"))?;
+  }
+  Ok(scalar.unwrap())
+}
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 struct CoefficientIndex {
@@ -114,6 +127,29 @@ impl<F: From<u64> + Zeroize + PrimeField> Poly<F> {
       x_coefficients: vec![],
       zero_coefficient: F::ZERO,
     }
+  }
+
+  /// Write the Polynomial
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    write_vec(|coeff, w| w.write_all(coeff.to_repr().as_ref()), &self.y_coefficients, w)?;
+    write_vec(
+      |coeff_vec, w| write_vec(|coeff, w| w.write_all(coeff.to_repr().as_ref()), &coeff_vec, w),
+      &self.yx_coefficients,
+      w,
+    )?;
+    write_vec(|coeff, w| w.write_all(coeff.to_repr().as_ref()), &self.x_coefficients, w)?;
+    w.write_all(self.zero_coefficient.to_repr().as_ref())
+  }
+
+  /// Read a Polynomial
+  pub fn read(reader: &mut impl io::Read) -> io::Result<Self> {
+    let y_coefficients = read_vec(|reader| read_scalar(reader), reader)?;
+    let yx_coefficients =
+      read_vec(|reader| read_vec(|reader| read_scalar(reader), reader), reader)?;
+    let x_coefficients = read_vec(|reader| read_scalar(reader), reader)?;
+    let zero_coefficient = read_scalar(reader)?;
+
+    Ok(Self { y_coefficients, yx_coefficients, x_coefficients, zero_coefficient })
   }
 }
 

--- a/crypto/divisors/src/poly.rs
+++ b/crypto/divisors/src/poly.rs
@@ -133,7 +133,7 @@ impl<F: From<u64> + Zeroize + PrimeField> Poly<F> {
   pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
     write_vec(|coeff, w| w.write_all(coeff.to_repr().as_ref()), &self.y_coefficients, w)?;
     write_vec(
-      |coeff_vec, w| write_vec(|coeff, w| w.write_all(coeff.to_repr().as_ref()), &coeff_vec, w),
+      |coeff_vec, w| write_vec(|coeff, w| w.write_all(coeff.to_repr().as_ref()), coeff_vec, w),
       &self.yx_coefficients,
       w,
     )?;

--- a/crypto/divisors/src/tests/poly.rs
+++ b/crypto/divisors/src/tests/poly.rs
@@ -146,3 +146,21 @@ fn test_differentation() {
     }
   );
 }
+
+#[test]
+fn test_read_write() {
+  let random = || F::random(&mut OsRng);
+
+  let input = Poly {
+    y_coefficients: vec![random()],
+    yx_coefficients: vec![vec![random()]],
+    x_coefficients: vec![random(), random(), random()],
+    zero_coefficient: random(),
+  };
+
+  let mut buf = vec![];
+  input.write(&mut buf).unwrap();
+
+  let input2 = Poly::read(&mut buf.as_slice()).unwrap();
+  assert_eq!(input, input2);
+}

--- a/crypto/fcmps/src/prover/blinds.rs
+++ b/crypto/fcmps/src/prover/blinds.rs
@@ -2,7 +2,10 @@ use core::ops::Deref;
 
 use zeroize::{Zeroize, Zeroizing};
 
-use ciphersuite::group::{ff::{PrimeFieldBits, PrimeField}, prime::PrimeGroup};
+use ciphersuite::group::{
+  ff::{PrimeFieldBits, PrimeField},
+  prime::PrimeGroup,
+};
 
 use ec_divisors::{Poly, DivisorCurve, ScalarDecomposition};
 

--- a/crypto/fcmps/src/prover/blinds.rs
+++ b/crypto/fcmps/src/prover/blinds.rs
@@ -2,14 +2,16 @@ use core::ops::Deref;
 
 use zeroize::{Zeroize, Zeroizing};
 
-use ciphersuite::group::ff::PrimeFieldBits;
+use ciphersuite::group::{ff::{PrimeFieldBits, PrimeField}, prime::PrimeGroup};
 
 use ec_divisors::{Poly, DivisorCurve, ScalarDecomposition};
+
+use std_shims::io;
 
 use crate::{Output, Input, FcmpError};
 
 #[derive(Clone, Zeroize)]
-pub(crate) struct ScalarMulAndDivisor<G: DivisorCurve> {
+pub(crate) struct ScalarMulAndDivisor<G: DivisorCurve + PrimeGroup> {
   /// The point resulting from this scalar multiplication.
   pub(crate) point: Zeroizing<G>,
   /// The `x` coordinate of the result of this scalar multiplication.
@@ -21,7 +23,32 @@ pub(crate) struct ScalarMulAndDivisor<G: DivisorCurve> {
   pub(crate) divisor: Poly<G::FieldElement>,
 }
 
-impl<G: DivisorCurve> ScalarMulAndDivisor<G>
+// Helper function to read a point
+fn read_point<G: PrimeGroup>(r: &mut impl io::Read) -> io::Result<G> {
+  let mut repr = G::Repr::default();
+  r.read_exact(repr.as_mut())?;
+  let point = G::from_bytes(&repr);
+  let Some(point) = Option::<G>::from(point) else {
+    Err(io::Error::new(io::ErrorKind::Other, "invalid point"))?
+  };
+  if point.to_bytes().as_ref() != repr.as_ref() {
+    Err(io::Error::new(io::ErrorKind::Other, "non-canonical point"))?;
+  }
+  Ok(point)
+}
+
+// Helper function to read a scalar
+fn read_scalar<F: PrimeField>(r: &mut impl io::Read) -> io::Result<F> {
+  let mut repr = F::Repr::default();
+  r.read_exact(repr.as_mut())?;
+  let scalar = F::from_repr(repr);
+  if scalar.is_none().into() {
+    Err(io::Error::new(io::ErrorKind::Other, "invalid scalar"))?;
+  }
+  Ok(scalar.unwrap())
+}
+
+impl<G: DivisorCurve + PrimeGroup> ScalarMulAndDivisor<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -31,11 +58,26 @@ where
     let divisor = scalar.scalar_mul_divisor(A).normalize_x_coefficient();
     ScalarMulAndDivisor { point, x, y, divisor }
   }
+
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    w.write_all((*self.point).to_bytes().as_ref())?;
+    w.write_all(self.x.to_repr().as_ref())?;
+    w.write_all(self.y.to_repr().as_ref())?;
+    self.divisor.write(w)
+  }
+
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    let point = Zeroizing::new(read_point(r)?);
+    let x = read_scalar(r)?;
+    let y = read_scalar(r)?;
+    let divisor = Poly::read(r)?;
+    Ok(Self { point, x, y, divisor })
+  }
 }
 
 /// A blind, prepared for usage within the circuit.
 #[derive(Clone, Zeroize)]
-pub(crate) struct PreparedBlind<G: DivisorCurve>
+pub(crate) struct PreparedBlind<G: DivisorCurve + PrimeGroup>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -43,7 +85,7 @@ where
   pub(crate) scalar_mul_and_divisor: ScalarMulAndDivisor<G>,
 }
 
-impl<G: DivisorCurve> PreparedBlind<G>
+impl<G: DivisorCurve + PrimeGroup> PreparedBlind<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -51,14 +93,25 @@ where
     let scalar_mul_and_divisor = ScalarMulAndDivisor::new(A, &scalar);
     PreparedBlind { scalar, scalar_mul_and_divisor }
   }
+
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    self.scalar.write(w)?;
+    self.scalar_mul_and_divisor.write(w)
+  }
+
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    let scalar = ScalarDecomposition::<G::Scalar>::read(r)?;
+    let scalar_mul_and_divisor = ScalarMulAndDivisor::<G>::read(r)?;
+    Ok(Self { scalar, scalar_mul_and_divisor })
+  }
 }
 
 /// A blind for `O` (the output's key).
 #[derive(Clone, Zeroize)]
-pub struct OBlind<G: DivisorCurve>(pub(crate) PreparedBlind<G>)
+pub struct OBlind<G: DivisorCurve + PrimeGroup>(pub(crate) PreparedBlind<G>)
 where
   G::Scalar: Zeroize + PrimeFieldBits;
-impl<G: DivisorCurve> OBlind<G>
+impl<G: DivisorCurve + PrimeGroup> OBlind<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -71,11 +124,21 @@ where
   {
     Self(PreparedBlind::new(T, scalar))
   }
+
+  /// Write the OBlind
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    self.0.write(w)
+  }
+
+  /// Read the OBlind
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    Ok(Self(PreparedBlind::<G>::read(r)?))
+  }
 }
 
 /// A blind for `I` (the output's key image generator).
 #[derive(Clone, Zeroize)]
-pub struct IBlind<G: DivisorCurve>
+pub struct IBlind<G: DivisorCurve + PrimeGroup>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -83,7 +146,7 @@ where
   pub(crate) u: ScalarMulAndDivisor<G>,
   pub(crate) v: ScalarMulAndDivisor<G>,
 }
-impl<G: DivisorCurve> IBlind<G>
+impl<G: DivisorCurve + PrimeGroup> IBlind<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -96,14 +159,29 @@ where
     let v = ScalarMulAndDivisor::new(V, &scalar);
     IBlind { scalar, u, v }
   }
+
+  /// Write the IBlind
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    self.scalar.write(w)?;
+    self.u.write(w)?;
+    self.v.write(w)
+  }
+
+  /// Read the IBlind
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    let scalar = ScalarDecomposition::<G::Scalar>::read(r)?;
+    let u = ScalarMulAndDivisor::<G>::read(r)?;
+    let v = ScalarMulAndDivisor::<G>::read(r)?;
+    Ok(Self { scalar, u, v })
+  }
 }
 
 /// A blind for `I`'s blind.
 #[derive(Clone, Zeroize)]
-pub struct IBlindBlind<G: DivisorCurve>(pub(crate) PreparedBlind<G>)
+pub struct IBlindBlind<G: DivisorCurve + PrimeGroup>(pub(crate) PreparedBlind<G>)
 where
   G::Scalar: Zeroize + PrimeFieldBits;
-impl<G: DivisorCurve> IBlindBlind<G>
+impl<G: DivisorCurve + PrimeGroup> IBlindBlind<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -113,14 +191,24 @@ where
   pub fn new(T: G, scalar: ScalarDecomposition<G::Scalar>) -> Self {
     Self(PreparedBlind::new(T, scalar))
   }
+
+  /// Write the IBlindBlind
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    self.0.write(w)
+  }
+
+  /// Read the IBlindBlind
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    Ok(Self(PreparedBlind::<G>::read(r)?))
+  }
 }
 
 /// A blind for `C` (the output's commitment).
 #[derive(Clone, Zeroize)]
-pub struct CBlind<G: DivisorCurve>(pub(crate) PreparedBlind<G>)
+pub struct CBlind<G: DivisorCurve + PrimeGroup>(pub(crate) PreparedBlind<G>)
 where
   G::Scalar: Zeroize + PrimeFieldBits;
-impl<G: DivisorCurve> CBlind<G>
+impl<G: DivisorCurve + PrimeGroup> CBlind<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -130,11 +218,21 @@ where
   pub fn new(G: G, scalar: ScalarDecomposition<G::Scalar>) -> Self {
     Self(PreparedBlind::new(G, scalar))
   }
+
+  /// Write the CBlind
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    self.0.write(w)
+  }
+
+  /// Read the IBlindBlind
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    Ok(Self(PreparedBlind::<G>::read(r)?))
+  }
 }
 
 /// All of the blinds used for an output, prepared for usage within the circuit.
 #[derive(Clone, Zeroize)]
-pub struct OutputBlinds<G: DivisorCurve>
+pub struct OutputBlinds<G: DivisorCurve + PrimeGroup>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -144,7 +242,7 @@ where
   pub(crate) c_blind: CBlind<G>,
 }
 
-impl<G: DivisorCurve> OutputBlinds<G>
+impl<G: DivisorCurve + PrimeGroup> OutputBlinds<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -179,14 +277,32 @@ where
     let R = *self.i_blind_blind.0.scalar_mul_and_divisor.point - self.i_blind.v.point.deref();
     Input::new(O_tilde, I_tilde, R, C_tilde)
   }
+
+  /// Write the OutputBlind to writable
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    self.o_blind.write(w)?;
+    self.i_blind.write(w)?;
+    self.i_blind_blind.write(w)?;
+    self.c_blind.write(w)
+  }
+
+  /// Read the OutputBlind
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    let o_blind = OBlind::<G>::read(r)?;
+    let i_blind = IBlind::<G>::read(r)?;
+    let i_blind_blind = IBlindBlind::<G>::read(r)?;
+    let c_blind = CBlind::<G>::read(r)?;
+
+    Ok(Self { o_blind, i_blind, i_blind_blind, c_blind })
+  }
 }
 
 /// A blind for a branch.
 #[derive(Clone, Zeroize)]
-pub struct BranchBlind<G: DivisorCurve>(pub(crate) PreparedBlind<G>)
+pub struct BranchBlind<G: DivisorCurve + PrimeGroup>(pub(crate) PreparedBlind<G>)
 where
   G::Scalar: Zeroize + PrimeFieldBits;
-impl<G: DivisorCurve> BranchBlind<G>
+impl<G: DivisorCurve + PrimeGroup> BranchBlind<G>
 where
   G::Scalar: Zeroize + PrimeFieldBits,
 {
@@ -195,5 +311,15 @@ where
   /// This will calculate a divisor and is computationally non-trivial.
   pub fn new(H: G, scalar: ScalarDecomposition<G::Scalar>) -> Self {
     Self(PreparedBlind::new(H, scalar))
+  }
+
+  /// Write the Branch Blind
+  pub fn write<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
+    self.0.write(w)
+  }
+
+  /// Read the Branch Blind
+  pub fn read(r: &mut impl io::Read) -> io::Result<Self> {
+    Ok(Self(PreparedBlind::<G>::read(r)?))
   }
 }

--- a/crypto/fcmps/src/prover/mod.rs
+++ b/crypto/fcmps/src/prover/mod.rs
@@ -329,7 +329,7 @@ where
       // Accumulate the opening for the leaves
       let append_claimed_point =
         |c1_tape: &mut VectorCommitmentTape<<C::C1 as Ciphersuite>::F>,
-         dlog: &[u64],
+         dlog: &[u8],
          scalar_mul_and_divisor: ScalarMulAndDivisor<<C::OC as Ciphersuite>::G>,
          padding| {
           c1_tape.append_claimed_point::<C::OcParameters>(

--- a/crypto/fcmps/src/tape.rs
+++ b/crypto/fcmps/src/tape.rs
@@ -103,7 +103,7 @@ impl<F: Zeroize + PrimeFieldBits> VectorCommitmentTape<F> {
   /// elements are provided in `padding` than free spaces remaining.
   pub(crate) fn append_dlog<Parameters: DiscreteLogParameters>(
     &mut self,
-    dlog: Option<&[u64]>,
+    dlog: Option<&[u8]>,
     padding: Option<Vec<F>>,
     extra: Option<F>,
   ) -> (GenericArray<Variable, Parameters::ScalarBits>, Vec<Variable>, Variable) {
@@ -114,7 +114,7 @@ impl<F: Zeroize + PrimeFieldBits> VectorCommitmentTape<F> {
       let mut witness = vec![];
       assert_eq!(dlog.len(), dlog_bits);
       for coeff in dlog {
-        witness.push(F::from(*coeff));
+        witness.push(F::from(u64::from(*coeff)));
       }
 
       let padding = padding.unwrap();
@@ -214,7 +214,7 @@ impl<F: Zeroize + PrimeFieldBits> VectorCommitmentTape<F> {
 
   pub(crate) fn append_claimed_point<Parameters: DiscreteLogParameters>(
     &mut self,
-    dlog: Option<&[u64]>,
+    dlog: Option<&[u8]>,
     divisor: Option<Poly<F>>,
     point: Option<(F, F)>,
     padding: Option<Vec<F>>,


### PR DESCRIPTION
Marked as draft because this modifies divisors (divisors current source is used in [the competition](https://github.com/j-berman/fcmp-plus-plus-optimization-competition)), and figure makes sense not to modify divisors with non-critical changes until the competition is over.

This change is useful to save pre-calculated blinds in the wallet cache: https://github.com/seraphis-migration/monero/pull/25

Couple highlights worth pointing out:
- The bit decomposition vector was using u64's instead of u8's, and looks like using u8's as implemented should be fine.
- I added a dep to `monero-io` in the `divisors` crate.
  - This feels counter to the `divisors` crate's intent to be general-purpose rather than Monero-specific.
  - I did it so I could re-use `write_vec` and `read_vec`, which as implemented don't look Monero-specific.