### PR TITLE
Pass *proof_len directly into read fn's

### DIFF
--- a/crypto/fcmps/src/lib.rs
+++ b/crypto/fcmps/src/lib.rs
@@ -993,8 +993,8 @@ where
   }
 
   /// Read an FCMP.
-  pub fn read(reader: &mut impl io::Read, inputs: usize, layers: usize) -> io::Result<Self> {
-    let mut proof = vec![0; Self::proof_size(inputs, layers) - 64];
+  pub fn read(reader: &mut impl io::Read, membership_proof_len: usize) -> io::Result<Self> {
+    let mut proof = vec![0; membership_proof_len - 64];
     reader.read_exact(&mut proof)?;
     let mut root_blind_pok = [0; 64];
     reader.read_exact(&mut root_blind_pok)?;

--- a/crypto/fcmps/src/tests.rs
+++ b/crypto/fcmps/src/tests.rs
@@ -629,7 +629,7 @@ fn test_malleated_proofs() {
         while buf[i] == existing_byte {
           buf[i] = u8::try_from(OsRng.next_u64() & u64::from(u8::MAX)).unwrap();
         }
-        let membership_proof_len = Fcmp::proof_size(paths.len(), layers);
+        let membership_proof_len = Fcmp::<MoneroCurves>::proof_size(paths.len(), layers);
         if let Ok(proof) = Fcmp::read(&mut buf.as_slice(), membership_proof_len) {
           let mut verifier_1 = generalized_bulletproofs::Generators::batch_verifier();
           let mut verifier_2 = generalized_bulletproofs::Generators::batch_verifier();

--- a/crypto/fcmps/src/tests.rs
+++ b/crypto/fcmps/src/tests.rs
@@ -629,7 +629,8 @@ fn test_malleated_proofs() {
         while buf[i] == existing_byte {
           buf[i] = u8::try_from(OsRng.next_u64() & u64::from(u8::MAX)).unwrap();
         }
-        if let Ok(proof) = Fcmp::read(&mut buf.as_slice(), paths.len(), layers) {
+        let membership_proof_len = Fcmp::proof_size(paths.len(), layers);
+        if let Ok(proof) = Fcmp::read(&mut buf.as_slice(), membership_proof_len) {
           let mut verifier_1 = generalized_bulletproofs::Generators::batch_verifier();
           let mut verifier_2 = generalized_bulletproofs::Generators::batch_verifier();
 

--- a/networks/monero/ringct/fcmp++/src/lib.rs
+++ b/networks/monero/ringct/fcmp++/src/lib.rs
@@ -262,6 +262,10 @@ pub struct FcmpPlusPlus {
   fcmp: Fcmp<Curves>,
 }
 
+fn input_tuple_and_sal_proof_size(inputs: usize) -> usize {
+  inputs * ((3 * 32) + (12 * 32))
+}
+
 impl FcmpPlusPlus {
   /// Create a new FCMP++ proof from its components.
   pub fn new(inputs: Vec<(Input, SpendAuthAndLinkability)>, fcmp: Fcmp<Curves>) -> FcmpPlusPlus {
@@ -271,7 +275,7 @@ impl FcmpPlusPlus {
   /// The size of a FCMP++ proof.
   pub fn proof_size(inputs: usize, layers: usize) -> usize {
     // Each input tuple, without C~, each SAL, and the FCMP
-    (inputs * ((3 * 32) + (12 * 32))) + Fcmp::<Curves>::proof_size(inputs, layers)
+    input_tuple_and_sal_proof_size(inputs) + Fcmp::<Curves>::proof_size(inputs, layers)
   }
 
   /// Write a FCMP++ proof.
@@ -293,7 +297,7 @@ impl FcmpPlusPlus {
   /// that.
   pub fn read(
     pseudo_outs: &[[u8; 32]],
-    layers: usize,
+    proof_len: usize,
     reader: &mut impl io::Read,
   ) -> io::Result<Self> {
     let mut inputs = vec![];
@@ -301,7 +305,10 @@ impl FcmpPlusPlus {
       let C_tilde = Ed25519::read_G(&mut pseudo_out.as_slice())?;
       inputs.push((Input::read_partial(C_tilde, reader)?, SpendAuthAndLinkability::read(reader)?));
     }
-    let fcmp = Fcmp::read(reader, pseudo_outs.len(), layers)?;
+    let membership_proof_len = proof_len
+      .checked_sub(input_tuple_and_sal_proof_size(inputs.len()))
+      .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "proof_len provided is too small"))?;
+    let fcmp = Fcmp::read(reader, membership_proof_len)?;
     Ok(Self { inputs, fcmp })
   }
 

--- a/networks/monero/ringct/fcmp++/src/tests/mod.rs
+++ b/networks/monero/ringct/fcmp++/src/tests/mod.rs
@@ -111,7 +111,7 @@ fn test() {
   fcmp_plus_plus.write(&mut buf).unwrap();
   assert_eq!(FcmpPlusPlus::proof_size(1, 1), buf.len());
   let fcmp_plus_plus =
-    FcmpPlusPlus::read(&[input.C_tilde().to_bytes()], 1, &mut buf.as_slice()).unwrap();
+    FcmpPlusPlus::read(&[input.C_tilde().to_bytes()], buf.len(), &mut buf.as_slice()).unwrap();
 
   fcmp_plus_plus
     .verify(


### PR DESCRIPTION
This way de-serialization doesn't require expensive call for proof size

Additionally the caller can handle tabling for the proof size